### PR TITLE
Use put() instead of add()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jdk:
   - oraclejdk8
 addons:
   sonarcloud:
-    organization: metafacture
+    organization: hbz
     token: $SONARCLOUD_TOKEN
 cache:
   directories:

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectPipeDecoupler.java
@@ -97,13 +97,17 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
 
     @Override
     public void resetStream() {
-        queue.add(Feeder.BLUE_PILL);
+        try {
+            queue.put(Feeder.BLUE_PILL);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     @Override
     public void closeStream() {
-        queue.add(Feeder.RED_PILL);
         try {
+            queue.put(Feeder.RED_PILL);
             thread.join();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -147,6 +151,7 @@ public final class ObjectPipeDecoupler<T> implements ObjectPipe<T, ObjectReceive
                 }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                return;
             }
         }
     }

--- a/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
+++ b/metafacture-flowcontrol/src/main/java/org/metafacture/flowcontrol/ObjectThreader.java
@@ -15,7 +15,6 @@
 
 package org.metafacture.flowcontrol;
 
-import org.metafacture.flowcontrol.ObjectPipeDecoupler;
 import org.metafacture.framework.ObjectPipe;
 import org.metafacture.framework.ObjectReceiver;
 import org.metafacture.framework.Tee;
@@ -59,7 +58,7 @@ public class ObjectThreader<T> extends DefaultTee<ObjectReceiver<T>> implements 
 
     @Override
     public Tee<ObjectReceiver<T>> addReceiver(final ObjectReceiver<T> receiver) {
-        LOG.info("Adding thread " + (getReceivers().size() + 1));
+        LOG.info("Adding thread {0}" + (getReceivers().size() + 1));
         ObjectPipeDecoupler<T> opd = new ObjectPipeDecoupler<>();
         opd.setReceiver(receiver);
         return super.addReceiver(opd);


### PR DESCRIPTION
While add() throws an IllegalStateException if the Queue is full, a put()
just waits until there is space left in Queue.

- add "return"
The usage of "return" is encouraged to make sure to stop a thread when it's
interrupted.

Resolves hbz/lobid-resources#980.